### PR TITLE
ci: switch publish workflow to manual trigger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,56 +1,54 @@
 name: Publish to NPM and Create Release
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Use Node.js 18.17.0
-      uses: actions/setup-node@v2
-      with:
-        node-version: '18.17.0'
-        registry-url: https://registry.npmjs.org
+      - name: Use Node.js 18.17.0
+        uses: actions/setup-node@v2
+        with:
+          node-version: "18.17.0"
+          registry-url: https://registry.npmjs.org
 
-    - name: Install pnpm
-      run: curl -f https://get.pnpm.io/v6.js | node - add --global pnpm
+      - name: Install pnpm
+        run: curl -f https://get.pnpm.io/v6.js | node - add --global pnpm
 
-    - name: Install dependencies
-      run: pnpm install
+      - name: Install dependencies
+        run: pnpm install
 
-    - name: Build
-      run: pnpm build
+      - name: Build
+        run: pnpm build
 
-    - name: Configure Git User
-      run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
+      - name: Configure Git User
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
 
-    - name: Generate Changelog and Bump Version
-      run: npx standard-version
+      - name: Generate Changelog and Bump Version
+        run: npx standard-version
 
-    - name: Get version
-      run: echo "VERSION=$(jq -r '.version' package.json)" >> $GITHUB_ENV
+      - name: Get version
+        run: echo "VERSION=$(jq -r '.version' package.json)" >> $GITHUB_ENV
 
-    - name: Publish to NPM
-      run: pnpm publish --access public --no-git-checks
-      env:
-        NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
+      - name: Publish to NPM
+        run: pnpm publish --access public --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
 
-    - name: Set Release Description
-      run: echo "RELEASE_BODY=$(sed -n '/^## \[v'${{ env.VERSION }}'\]/,/^## \[v[0-9.]+\]/p' CHANGELOG.md)" >> $GITHUB_ENV
+      - name: Set Release Description
+        run: echo "RELEASE_BODY=$(sed -n '/^## \[v'${{ env.VERSION }}'\]/,/^## \[v[0-9.]+\]/p' CHANGELOG.md)" >> $GITHUB_ENV
 
-    - name: Create GitHub Release
-      uses: actions/create-release@v1
-      with:
-        tag_name: v${{ env.VERSION }}
-        release_name: Release v${{ env.VERSION }}
-        body: ${{ env.RELEASE_BODY }}
-        draft: false
-        prerelease: false
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        with:
+          tag_name: v${{ env.VERSION }}
+          release_name: Release v${{ env.VERSION }}
+          body: ${{ env.RELEASE_BODY }}
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 📌 Summary
Switch the npm publish workflow from auto-trigger on `push` to `main` to a manual `workflow_dispatch` trigger, so that merging multiple cleanup PRs into `main` does not produce a release per merge.

## 🔧 Changes
- `.github/workflows/publish.yml`: replace `on: push.branches: [main]` with `on: workflow_dispatch`.

## 🎯 Motivation
Several follow-up PRs are being prepared (user-visible bug fixes, type/quality refactor, CI hardening, tests). With the current trigger, every merge would publish a new npm version, polluting the changelog and forcing the version to bump on README/CI/test changes. We want to merge all the cleanup work first and then publish a single consolidated release.

This is the minimal change to unblock that flow. A larger CI overhaul (action version bumps, replacement of `standard-version`, pnpm install method) is intentionally deferred to a later PR.

## 🧪 Testing
- After this PR is merged, push events to `main` should not start `Publish to NPM and Create Release`.
- A release can still be cut on demand via the Actions UI ("Run workflow") or `gh workflow run publish.yml`.

## ⚠️ Risks / Impact
- Until a release is manually triggered, no new npm version will be published from `main`. This is the desired behavior for the duration of the cleanup batch.
- `standard-version` and the rest of the publish steps are untouched; the workflow still works the same once dispatched.

## 🔁 Backward Compatibility
- Fully backward-compatible from a consumer perspective; only the publish trigger changes.