### PR TITLE
fix: user-visible bugs (CDN URL, file ext, credentials)

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -155,7 +155,8 @@ export = {
 
     function getFileKey(file: File): string {
       const path = file.path ? `${file.path}/` : "";
-      return `${filePrefix}${path}${file.hash}${file.ext}`;
+      const ext = file.ext ?? "";
+      return `${filePrefix}${path}${file.hash}${ext}`;
     }
 
     function upload(file: File): Promise<void> {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -82,6 +82,12 @@ export = {
     const filePrefix = StorageRootPath
       ? `${StorageRootPath.replace(/\/+$/, "")}/`
       : "";
+    const normalizedCDNDomain = CDNDomain
+      ? (/^https?:\/\//i.test(CDNDomain)
+          ? CDNDomain
+          : `https://${CDNDomain}`
+        ).replace(/\/+$/, "")
+      : undefined;
     // init COS
     const cos = new COS(COSInitConfig);
 
@@ -175,8 +181,8 @@ export = {
           function (err, data) {
             log({ err, data, size: file.size });
             if (err) return reject(err);
-            if (CDNDomain) {
-              file.url = `${CDNDomain}/${Key}`;
+            if (normalizedCDNDomain) {
+              file.url = `${normalizedCDNDomain}/${Key}`;
             } else {
               file.url = `https://${data.Location}`;
             }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -36,7 +36,7 @@ interface ConfigOptions {
   >;
   // access control list for the bucket
   ACL?: "private" | "default";
-  // the expiration time of the signature file(millisecond)
+  // the expiration time of the signed URL (in seconds)
   Expires?: number;
   CDNDomain?: string;
   StorageRootPath?: string;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -25,8 +25,8 @@ interface File {
 }
 
 interface ConfigOptions {
-  SecretId: string;
-  SecretKey: string;
+  SecretId?: string;
+  SecretKey?: string;
   initOptions?: COSOptions;
   Bucket: string;
   Region: string;
@@ -69,14 +69,15 @@ export = {
       SecretKey,
       ...config.initOptions,
     };
-    if (
-      (COSInitConfig.SecretId && COSInitConfig.SecretKey) ||
-      COSInitConfig.getAuthorization
-    ) {
-    } else
+    const hasStaticCredentials = Boolean(
+      COSInitConfig.SecretId && COSInitConfig.SecretKey,
+    );
+    const hasAuthorizationFn = Boolean(COSInitConfig.getAuthorization);
+    if (!hasStaticCredentials && !hasAuthorizationFn) {
       throw new Error(
         "getAuthorization or SecretId and SecretKey must be provided",
       );
+    }
 
     const filePrefix = StorageRootPath
       ? `${StorageRootPath.replace(/\/+$/, "")}/`


### PR DESCRIPTION
## 📌 Summary
Fix four user-visible bugs in the Tencent COS upload provider:
1. CDN URL produced without protocol or with double slashes
2. File key gaining a literal `undefined` suffix when `file.ext` is missing
3. Misleading comment on the `Expires` option
4. Awkward empty-if + else-throw guard for credentials

This is the first cleanup PR in a series; subsequent PRs will cover type/quality refactor, tests, and CI hardening.

## 🔧 Changes
Four atomic commits in `lib/index.ts`:

- `docs: correct Expires unit comment to seconds`
  Comment claimed `millisecond`, but `cos.getObjectUrl` accepts `Expires` in seconds (also matches the README "default 360 seconds").

- `refactor: clarify credentials precondition check`
  Replace `if (cond) {} else throw` with `if (!cond) throw`. Mark `SecretId`/`SecretKey` optional in `ConfigOptions` to reflect that `getAuthorization` (via `initOptions`) is a valid alternative.

- `fix: avoid literal 'undefined' suffix when file.ext is missing`
  `file.ext` is typed as optional; previous template-literal join produced keys like `<hash>undefined`. Use `file.ext ?? ""`.

- `fix(cdn): normalize CDNDomain protocol and trailing slash`
  When `CDNDomain` is configured without a scheme (e.g. `cdn.example.com`, as the README example shows), the resulting `file.url` was a relative-looking string. We now prepend `https://` if no scheme is present and strip any trailing slash so `${CDNDomain}/${Key}` cannot become `https://cdn.example.com//key`.

## 🎯 Motivation
- The CDN URL bug means users following the README literally would store malformed URLs in Strapi.
- The `undefined` suffix bug silently corrupts object keys for files Strapi delivers without an extension.
- The other two are correctness/clarity improvements that touched adjacent code.

## 🧪 Testing
- `pnpm build` (tsc) passes after each commit.
- No automated tests added in this PR; a vitest baseline + per-fix unit tests are planned for the CI/quality PR later in the series.
- Manual verification path: configuring `CDNDomain: "cdn.example.com"` (no scheme) and `CDNDomain: "https://cdn.example.com/"` (trailing slash) both now yield `https://cdn.example.com/<key>`.

## ⚠️ Risks / Impact
- `SecretId`/`SecretKey` becoming optional in the `ConfigOptions` type is a relaxation, not a breaking change for callers.
- `CDNDomain` normalization changes the value used at upload time. Any user who was already passing `https://...` and relying on a trailing slash to produce a double-slash URL would see different output — extremely unlikely and arguably a fix.
- The `undefined`-suffix fix changes the storage key for `file.ext === undefined` only. Files already uploaded with the buggy key remain accessible via their existing key; new uploads will use the corrected key.

## 🔁 Backward Compatibility
- API surface unchanged (no exported names added or removed).
- No new dependencies, no config schema changes beyond `SecretId`/`SecretKey` becoming optional.