### PR TITLE
feat: pass ContentType and expose uploadStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ module.exports = ({ env }) => ({
 
 If your bucket is configured to be private, you will need to set the `ACL` option to `private` in the `params` object. This will ensure file URLs are signed.
 
-**Note:** If you are using a CDN, the URLs will not be signed.
+**Note:** When `ACL` is `"private"`, signed URLs are generated against the COS bucket domain — `CDNDomain` is not used for signing (CDN authentication is a separate Tencent Cloud mechanism). Configuring both `ACL: "private"` and `CDNDomain` is not recommended.
 
 You can also define the expiration time of the signed URL by setting the `Expires` option in the `providerOptions` object. The default value is 360 seconds (6 minutes).
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ module.exports = ({ env }) => ({
 
 ### Configuration for a private COS bucket and signed URLs
 
-If your bucket is configured to be private, you will need to set the `ACL` option to `private` in the `params` object. This will ensure file URLs are signed.
+If your bucket is configured to be private, you will need to set the `ACL` option to `private` in `providerOptions`. This will ensure file URLs are signed.
 
 **Note:** When `ACL` is `"private"`, signed URLs are generated against the COS bucket domain — `CDNDomain` is not used for signing (CDN authentication is a separate Tencent Cloud mechanism). Configuring both `ACL: "private"` and `CDNDomain` is not recommended.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npm install strapi-provider-upload-tencent-cloud-storage --save
   - `ACL`: (optional) `"private"` to keep the bucket private and serve files via signed URLs, or `"default"` (default) to use the bucket's own ACL.
   - `Expires`: (optional) Expiration time of generated signed URLs, in **seconds**. Default `360` (6 minutes).
   - `initOptions`: (optional) Forwarded to the COS SDK constructor. See the full list of [COS init options](https://cloud.tencent.com/document/product/436/8629). Use this to configure `getAuthorization`, custom `Domain`, etc.
-  - `uploadOptions`: (optional) Forwarded to `cos.putObject`. See the full list of [putObject options](https://cloud.tencent.com/document/product/436/64980). `Bucket`, `Region`, `Key`, `Body`, `ContentLength` and `ContentType` are managed by the provider and cannot be overridden.
+  - `uploadOptions`: (optional) Forwarded to `cos.putObject`. See the full list of [putObject options](https://cloud.tencent.com/document/product/436/64980). `Bucket`, `Region`, `Key`, `Body` and `ContentType` are managed by the provider and cannot be overridden.
   - `CDNDomain`: (optional) CDN domain used to compose the public file URL. Both `cdn.example.com` and `https://cdn.example.com` are accepted; `https://` is added if no scheme is present, and trailing slashes are stripped.
   - `StorageRootPath`: (optional) Prefix inside the bucket. Trailing slashes are stripped automatically.
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -94,7 +94,7 @@ export = {
     return {
       upload,
 
-      // uploadStream: upload,
+      uploadStream: upload,
 
       delete(file: File): Promise<void> {
         const Key = getFileKey(file);
@@ -180,6 +180,11 @@ export = {
             Region,
             Key,
             Body: file.stream || file.buffer,
+            ContentType: file.mime,
+            // file.size is in KB; ContentLength must be bytes. Passing it
+            // explicitly avoids the SDK buffering the whole stream just to
+            // measure its length.
+            ContentLength: kbytesToBytes(file.size),
           },
           function (err, data) {
             log({ err, data, size: file.size });

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -32,7 +32,7 @@ interface ConfigOptions {
   Region: string;
   uploadOptions?: Omit<
     PutObjectParams,
-    "Bucket" | "Region" | "Key" | "Body" | "ContentLength" | "ContentType"
+    "Bucket" | "Region" | "Key" | "Body" | "ContentType"
   >;
   // access control list for the bucket
   ACL?: "private" | "default";
@@ -181,10 +181,6 @@ export = {
             Key,
             Body: file.stream || file.buffer,
             ContentType: file.mime,
-            // file.size is in KB; ContentLength must be bytes. Passing it
-            // explicitly avoids the SDK buffering the whole stream just to
-            // measure its length.
-            ContentLength: kbytesToBytes(file.size),
           },
           function (err, data) {
             log({ err, data, size: file.size });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -190,6 +190,57 @@ describe("upload: file.url composition (CDN normalization)", () => {
   });
 });
 
+describe("upload: ContentType and ContentLength", () => {
+  it("passes file.mime as ContentType to putObject", async () => {
+    const p = provider.init(baseConfig);
+    putObject.mockImplementation((_params, cb) =>
+      cb(null, { Location: "loc" }),
+    );
+    await p.upload(baseFile({ mime: "image/webp" }) as never);
+    expect(putObject.mock.calls[0][0].ContentType).toBe("image/webp");
+  });
+
+  it("passes ContentLength in bytes (file.size is in KB)", async () => {
+    const p = provider.init(baseConfig);
+    putObject.mockImplementation((_params, cb) =>
+      cb(null, { Location: "loc" }),
+    );
+    await p.upload(baseFile({ size: 100 }) as never);
+    // 100 KB -> 102400 bytes (per kbytesToBytes mock)
+    expect(putObject.mock.calls[0][0].ContentLength).toBe(100 * 1024);
+  });
+
+  it("does not let uploadOptions override ContentType / ContentLength", async () => {
+    const p = provider.init({
+      ...baseConfig,
+      // Cast: ConfigOptions.uploadOptions Omits these keys, but a JS
+      // consumer could still try to pass them — assert they're ignored.
+      uploadOptions: {
+        ContentType: "application/octet-stream",
+        ContentLength: 1,
+      } as never,
+    });
+    putObject.mockImplementation((_params, cb) =>
+      cb(null, { Location: "loc" }),
+    );
+    await p.upload(baseFile({ mime: "image/png", size: 50 }) as never);
+    expect(putObject.mock.calls[0][0].ContentType).toBe("image/png");
+    expect(putObject.mock.calls[0][0].ContentLength).toBe(50 * 1024);
+  });
+});
+
+describe("uploadStream", () => {
+  it("is exposed and aliases upload", async () => {
+    const p = provider.init(baseConfig);
+    expect(
+      typeof (p as unknown as { uploadStream?: unknown }).uploadStream,
+    ).toBe("function");
+    expect((p as unknown as { uploadStream: unknown }).uploadStream).toBe(
+      p.upload,
+    );
+  });
+});
+
 describe("upload: input validation", () => {
   it("rejects when neither stream nor buffer is provided", async () => {
     const p = provider.init(baseConfig);

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -190,7 +190,7 @@ describe("upload: file.url composition (CDN normalization)", () => {
   });
 });
 
-describe("upload: ContentType and ContentLength", () => {
+describe("upload: ContentType", () => {
   it("passes file.mime as ContentType to putObject", async () => {
     const p = provider.init(baseConfig);
     putObject.mockImplementation((_params, cb) =>
@@ -200,32 +200,32 @@ describe("upload: ContentType and ContentLength", () => {
     expect(putObject.mock.calls[0][0].ContentType).toBe("image/webp");
   });
 
-  it("passes ContentLength in bytes (file.size is in KB)", async () => {
-    const p = provider.init(baseConfig);
-    putObject.mockImplementation((_params, cb) =>
-      cb(null, { Location: "loc" }),
-    );
-    await p.upload(baseFile({ size: 100 }) as never);
-    // 100 KB -> 102400 bytes (per kbytesToBytes mock)
-    expect(putObject.mock.calls[0][0].ContentLength).toBe(100 * 1024);
-  });
-
-  it("does not let uploadOptions override ContentType / ContentLength", async () => {
+  it("does not let uploadOptions override ContentType", async () => {
     const p = provider.init({
       ...baseConfig,
-      // Cast: ConfigOptions.uploadOptions Omits these keys, but a JS
-      // consumer could still try to pass them — assert they're ignored.
+      // Cast: ConfigOptions.uploadOptions Omits ContentType, but a JS
+      // consumer could still try to pass it — assert it's ignored.
       uploadOptions: {
         ContentType: "application/octet-stream",
-        ContentLength: 1,
       } as never,
     });
     putObject.mockImplementation((_params, cb) =>
       cb(null, { Location: "loc" }),
     );
-    await p.upload(baseFile({ mime: "image/png", size: 50 }) as never);
+    await p.upload(baseFile({ mime: "image/png" }) as never);
     expect(putObject.mock.calls[0][0].ContentType).toBe("image/png");
-    expect(putObject.mock.calls[0][0].ContentLength).toBe(50 * 1024);
+  });
+
+  it("does not set ContentLength (file.size is rounded KB; left to the SDK)", async () => {
+    // Strapi's file.size is rounded to 2 decimal KB and would yield a
+    // non-integer byte count via kbytesToBytes. Letting the SDK measure
+    // the body itself avoids declaring a wrong Content-Length header.
+    const p = provider.init(baseConfig);
+    putObject.mockImplementation((_params, cb) =>
+      cb(null, { Location: "loc" }),
+    );
+    await p.upload(baseFile({ size: 0.98 }) as never);
+    expect(putObject.mock.calls[0][0].ContentLength).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## 📌 Summary
Pre-release fixes uncovered while reviewing the provider against the Tencent Cloud COS docs and the cos-nodejs-sdk-v5 contract. Aligns runtime behavior with what the README already promised, and corrects a misleading note about CDN + private ACL.

## 🔧 Changes
- **`cos.putObject` now sets `ContentType` (`file.mime`).** README already documented this as provider-managed; the code did not actually pass it.
- **Expose `uploadStream` as an alias of `upload`.** Strapi v4's upload contract prefers `uploadStream` when available; without it, Strapi buffers the entire file into memory before calling `upload`.
- **Add 3 unit tests** (27 total, was 23) covering: ContentType passthrough, that user-supplied `uploadOptions` cannot override ContentType, and that ContentLength is intentionally **not** set (see Risks below).
- **Fix a factually wrong README note**: previously said "If you are using a CDN, the URLs will not be signed". Signed URLs *are* generated when `ACL: "private"` — but against the COS bucket domain, not the configured `CDNDomain`. Replaced with an accurate note recommending against combining the two.

## 🎯 Motivation
- Without `ContentType`, COS stored objects defaulted to `application/octet-stream`, which breaks inline rendering of images and videos served via CDN — a silent UX regression that's easy to ship and hard to debug.
- Without `uploadStream`, the streaming code path in `upload` was effectively dead — Strapi would always hand us a buffered file.
- The CDN-signing note was actively misleading users diagnosing private + CDN setups.

## 🧪 Testing
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 27/27 passing
- [x] `pnpm build` — clean
- [x] **Smoke test against a real Strapi v4 + Tencent COS bucket** (see Smoke test results below)

## ✅ Smoke test results (post-merge, pre-publish)

Verified against a fresh `create-strapi-app@4` sandbox + a real `ap-shanghai` COS bucket:

| Check | Result |
| --- | --- |
| Small PNG upload via Media Library | OK |
| `curl -sI` on uploaded object → `Content-Type: image/png` | **OK — core PR fix confirmed** (was `application/octet-stream` before) |
| Strapi admin renders thumbnail inline (after CSP whitelist) | OK |
| Large file upload (130 MB `.dmg`) | OK |
| `Content-Type` of `.dmg` → `application/x-apple-diskimage` | OK — confirms ContentType is dynamically taken from `file.mime`, not hardcoded |
| Single putObject (no multipart, ETag has no `-N` suffix), no OOM on Strapi process | OK — `uploadStream` path works |
| Delete via Media Library → `curl -sI` returns `404 Not Found` | OK |

### Gotchas hit during smoke test (worth knowing for the next maintainer)

1. **Node version:** Strapi 4 requires Node `>=18 <=20`. Newer Node (e.g. 25) only emits `EBADENGINE` warnings during install but the actual `strapi develop` boot refuses to start with a clear error. Use `nvm use 18` (or equivalent) before `npx create-strapi-app@4`.
2. **`@types/minimatch` deprecated stub:** Fresh Strapi 4 + TypeScript projects fail with `error TS2688: Cannot find type definition file for 'minimatch'` because the package on npm is now a deprecated stub with no actual definitions. Workaround: add `"types": ["node"]` to `compilerOptions` in the sandbox project's `tsconfig.json` to disable implicit `@types/*` scanning.
3. **CSP needed for admin thumbnails:** The default `strapi::security` middleware blocks the COS domain in `img-src` / `media-src`, so admin thumbnails appear blank even though the file is uploaded correctly and Content-Type is right. Replace the string `'strapi::security'` in `config/middlewares.ts` with the object form documented in this provider's README. (curl on the file URL still works without this — useful for verifying that the upload itself succeeded independently of admin UI.)

## ⚠️ Risks / Impact
- **Behavior change:** Newly uploaded objects will have correct `Content-Type` headers in COS. Pre-existing objects are not affected. This is the intended fix, but it is a user-observable change — worth a minor version bump.
- **`uploadStream` alias:** Strictly additive on the public surface. Existing callers using `upload` continue to work.
- **Why no `ContentLength`:** An earlier draft of this PR also set `ContentLength: kbytesToBytes(file.size)`. Self-review caught that Strapi's `file.size` is rounded to two decimals in KB, so for nearly every real upload the byte count would be non-integer (e.g. a 1000-byte file ⇒ size=0.98 ⇒ 1003.52 bytes). HTTP Content-Length must be a non-negative integer; declaring a wrong length would cause COS to either hang waiting for missing bytes or reject the request. Letting the SDK measure the body itself is safer. `ContentLength` is therefore left out of `uploadOptions`'s Omit list so callers with an exact byte count can still set it explicitly.
- **No dependency changes, no config changes.**

## 🔁 Backward Compatibility
Backward compatible. No migration needed. Worth releasing as **1.2.0** rather than 1.1.5 because the Content-Type behavior change is observable in stored objects and `uploadStream` is a new public method.