### PR TITLE
ci: switch publish workflow to npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   publish:
@@ -55,9 +56,7 @@ jobs:
         run: git push --follow-tags origin HEAD:${{ github.ref_name }}
 
       - name: Publish to npm
-        run: pnpm publish --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+        run: pnpm publish --access public --no-git-checks --provenance
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## 📌 Summary
Replace the long-lived \`NPM_AUTH_TOKEN\` secret with npm's OIDC-based Trusted Publishing. Removes the deprecated Automation token, eliminates per-publish OTP prompts, and adds a signed provenance attestation to each release.

## 🔧 Changes
- Add \`id-token: write\` permission to the publish workflow (required for OIDC).
- Drop \`NODE_AUTH_TOKEN\` from the \`Publish to npm\` step; \`pnpm publish\` authenticates via the OIDC token automatically.
- Add \`--provenance\` so npm records a signed attestation linking the tarball to the source commit + workflow run.

## 🎯 Motivation
npm now flags Automation tokens as a security risk and pushes everyone toward Trusted Publishing. Trusted Publishing:
- removes the long-lived secret from GitHub (one less thing to rotate or leak)
- short-lived per-publish token, scoped to one OIDC claim
- produces a "Provenance" badge on the npm package page — a real supply-chain signal that this tarball came from this commit in this repo via this workflow

## ⚠️ Required one-time setup on npmjs.com (must do before merging)
1. https://www.npmjs.com/package/strapi-provider-upload-tencent-cloud-storage/access
2. "Publishing access" → "Add Trusted Publisher"
3. Configure: GitHub Actions, owner \`yclgkd\`, repo \`strapi-provider-upload-tencent-cloud-storage\`, workflow \`publish.yml\`, environment empty
4. Save

If this is not configured before the next release dispatch, the publish step will 403/404. The old \`NPM_AUTH_TOKEN\` secret can be deleted from GitHub Secrets after the first successful trusted-publishing release.

## 🧪 Testing
- Workflow YAML is well-formed (no schema changes that need testing)
- Real test happens at next release dispatch — there is no way to dry-run npm publish against trusted publishing without actually publishing

## 🔁 Backward Compatibility
N/A — this is CI-only, doesn't affect the published package or consumers. \`pnpm@10.32.1\` (pinned in this repo) supports OIDC trusted publishing.